### PR TITLE
Some minor editorial fixes

### DIFF
--- a/RouteOriginAttestation-2022.asn
+++ b/RouteOriginAttestation-2022.asn
@@ -30,15 +30,15 @@ ROAIPAddressFamily ::= SEQUENCE {
   addressFamily         OCTET STRING (SIZE(2)),
   addresses             SEQUENCE (SIZE(1..MAX)) OF ROAIPAddress }
 
--- Note: maxLength must be equal or larger than size of IPAddress, --
--- and equal or smaller to what the AFI context permits.           --
+-- maxLength must be greater than or equal to the size of IPAddress, --
+-- and smaller than or equal to what the AFI context permits.        --
 ROAIPAddress ::= SEQUENCE {
   address               IPAddress,
   maxLength             INTEGER (0..128) OPTIONAL }
 
--- Note: if the ROAIPAddressFamily's addressFamily is IPv4, the  --
--- IPAddress' size cannot exceed 32; conversely if addressFamily --
--- is IPv6, size can't exceed 128.                               --
+-- If the ROAIPAddressFamily's addressFamily is IPv4, the size of --
+-- the IPAddress cannot exceed 32. If addressFamily is IPv6, the  --
+-- size cannot exceed 128.                                        --
 IPAddress ::= BIT STRING (SIZE(0..128))
 
 END

--- a/draft-ietf-sidrops-rfc6482bis.xml
+++ b/draft-ietf-sidrops-rfc6482bis.xml
@@ -133,7 +133,7 @@
           This section summarizes the significant changes between <xref target="RFC6482"/> and the profile described in this document.
         </t>
         <ul>
-          <li>Clarifications on the requirements for IP Addresses and AS Identifiers X.509 certificate extension.</li>
+          <li>Clarifications on the requirements for the IP Addresses and AS Identifiers X.509 certificate extensions.</li>
           <li>Strengthening of ASN.1 formal notation and definitions.</li>
           <li>Incorporate errata.</li>
           <li>Add an example ROA payload and ROA as appendix.</li>
@@ -180,14 +180,14 @@
       <sourcecode type="asn.1" src="RouteOriginAttestation-2022.asn"/>
 
       <section>
-        <name>version</name>
+        <name>Element version</name>
         <t>
           The version number of the RouteOriginAttestation MUST be 0.
         </t>
       </section>
 
       <section>
-        <name>asID</name>
+        <name>Element asID</name>
         <t>
           The asID field contains the AS number that is authorized to originate routes to the given IP address prefixes.
         </t>
@@ -239,7 +239,7 @@
               <li>less than or equal to the maximum length (in bits) of an IP address in the applicable address family: 32 in case of IPv4 and 128 in case of IPv6.</li>
             </ul>
             <t>
-              For example, if the IP address prefix is 203.0.113.0/24 and the maxLength is 26, the AS is authorized to advertise any more-specific prefix with a maximum length of 26.
+              For example, if the IP address prefix is 203.0.113.0/24 and the maxLength is 26, the AS is authorized to advertise any more specific prefix with a maximum length of 26.
               In this example, the AS would be authorized to advertise 203.0.113.0/24, 203.0.113.128/25, or 203.0.113.192/26; but not 203.0.113.0/27.
               See <xref target="RFC9319"/> for more information on the use of maxLength.
             </t>


### PR DESCRIPTION
Adjust comments in the ASN.1 to match the language in the draft better. Avoid an unsightly apostrophe, drop a misplaced 'conversely' and use the same spelling of cannot twice. Fix grammar of a change description, add Element to two section headers for consistency and drop a hyphen.